### PR TITLE
Add default settings on focus

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -106,7 +106,9 @@ class SettingsPanel extends View
   isDefault: (name) ->
     params = {sources: [atom.config.getUserConfigPath()]}
     params.scope = [@options.scopeName] if @options.scopeName?
-    not atom.config.get(name, params)?
+    defaultValue = @getDefault(name)
+    value = atom.config.get(name, params)
+    not value or defaultValue is value
 
   getDefault: (name) ->
     params = {excludeSources: [atom.config.getUserConfigPath()]}
@@ -136,11 +138,20 @@ class SettingsPanel extends View
   bindEditors: ->
     @find('atom-text-editor[id]').views().forEach (editorView) =>
       editor = editorView.getModel()
+      editorElement = $(editorView.element)
       name = editorView.attr('id')
       type = editorView.attr('type')
 
       if defaultValue = @valueToString(@getDefault(name))
         editor.setPlaceholderText("Default: #{defaultValue}")
+
+      editorElement.on 'focus', =>
+        if @isDefault(name)
+          editorView.setText(@valueToString(@getDefault(name)) ? '')
+
+      editorElement.on 'blur', =>
+        if @isDefault(name)
+          editorView.setText('')
 
       @observe name, (value) =>
         if @isDefault(name)

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -51,6 +51,35 @@ describe "SettingsPanel", ->
       expect(sortedSettings).not.toBeNull
       expect(_.size(sortedSettings)).toBe 0
 
+  describe 'default settings', ->
+    beforeEach ->
+      config =
+        type: 'object'
+        properties:
+          haz:
+            name: 'haz'
+            title: 'Haz'
+            description: 'The haz setting'
+            type: 'string'
+            default: 'haz'
+      atom.config.setSchema("foo", config)
+      atom.config.setDefaults("foo", gong: 'gong')
+      expect(_.size(atom.config.get('foo'))).toBe 2
+      settingsPanel = new SettingsPanel("foo", {includeTitle: false})
+
+    it 'ensures default stays default', ->
+      expect(settingsPanel.getDefault('foo.haz')).toBe 'haz'
+      expect(settingsPanel.isDefault('foo.haz')).toBe true
+      settingsPanel.set('foo.haz', 'haz')
+      expect(settingsPanel.isDefault('foo.haz')).toBe true
+
+    it 'can be overwritten', ->
+      expect(settingsPanel.getDefault('foo.haz')).toBe 'haz'
+      expect(settingsPanel.isDefault('foo.haz')).toBe true
+      settingsPanel.set('foo.haz', 'newhaz')
+      expect(settingsPanel.isDefault('foo.haz')).toBe false
+      expect(atom.config.get('foo.haz')).toBe 'newhaz'
+
   describe 'grouped settings', ->
     beforeEach ->
       config =


### PR DESCRIPTION
Default settings are now added to the text field on focus and removed on blur.
